### PR TITLE
Update helm template for default config to use roleBindings

### DIFF
--- a/helm/templates/default-config.yaml
+++ b/helm/templates/default-config.yaml
@@ -12,34 +12,5 @@ spec:
     enable: true
     prefix: {{ .Values.defaultUserNamespaceConfig.autocreate.prefix }}
   {{- end }}
-  templates:
-  - name: default
----
-apiVersion: template.openshift.io/v1
-kind: Template
-metadata:
-  name: default
-  namespace: {{ include "userNamespaceOperator.namespaceName" . }}
-
-parameters:
-- name: PROJECT_NAME
-- name: PROJECT_ADMIN_USER
-
-objects:
-{{- range .Values.defaultUserNamespaceConfig.userRoles }}
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    creationTimestamp: null
-    name: {{ . }}:${PROJECT_ADMIN_USER}
-    namespace: ${PROJECT_NAME}
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: {{ . }}
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: User
-    name: ${PROJECT_ADMIN_USER}
-{{- end }}
-{{- end }}
+  roleBindings:
+    {{- toYaml .Values.defaultUserNamespaceConfig.roleBindings | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,8 +16,8 @@ defaultUserNamespaceConfig:
     description: User namespace for {user_name}.
     enable: true
     prefix: user-
-  userRoles:
-  - admin
+  roleBindings:
+  - roleName: admin
 
 selfProvision:
   create: true


### PR DESCRIPTION
This update to use the UserNamespaceConfig `spec.roleBindings` is much easier to manage and configure than using a template.